### PR TITLE
Standardized locale names

### DIFF
--- a/locale/fr_CA/locale.xml
+++ b/locale/fr_CA/locale.xml
@@ -11,7 +11,7 @@
   * ALM plugin localization strings
   -->
 
-<locale name="fr_CA" full_name="Français">
+<locale name="fr_CA" full_name="Français (Canada)">
 
 	<message key="plugins.generic.alm.displayName">PLugiciel ALM</message>
 	<message key="plugins.generic.alm.description">Plugiciel qui affiche des mesures au niveau de l'article. Pour utiliser le service ALM, vous devez avoir des DOIs. Cette exigence risque de disparaître dans le futur.</message>

--- a/locale/fr_FR/locale.xml
+++ b/locale/fr_FR/locale.xml
@@ -11,7 +11,7 @@
   * ALM plugin localization strings
   -->
 
-<locale name="fr_FR" full_name="Français">
+<locale name="fr_FR" full_name="Français (France)">
 
 	<message key="plugins.generic.alm.displayName">PLugiciel ALM</message>
 	<message key="plugins.generic.alm.description">Plugiciel qui affiche des métriques au niveau de l'article. Pour utiliser le service ALM, vous devez avoir des DOIs. Cette condition risque de disparaître dans le futur.</message>

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -11,6 +11,6 @@
   * ALM plugin localization strings
   -->
 
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.alm.senderTask.warning.noJournal">O plugin ALM não está activado em nenhuma revista. Não foi enviada nenhuma informação sobre artigo.</message>
 </locale>

--- a/locale/ru_RU/locale.xml
+++ b/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * ALM plugin localization strings for the ru_RU (Russian) locale.
+  * ALM plugin localization strings for the ru_RU (Русский) locale.
   * With updates from Pavel Pisklakov (revising translation). 
   -->
 
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 
 	<message key="plugins.generic.alm.displayName">Плагин «ALM»</message>
 	<message key="plugins.generic.alm.description">Этот плагин отображает метрики уровня статьи (Article Level Metrics). Для использования сервиса ALM, вам необходимо использовать DOI. В будущем, это требование может быть ослаблено.</message>

--- a/locale/tr_TR/locale.xml
+++ b/locale/tr_TR/locale.xml
@@ -11,7 +11,7 @@
   * ALM plugin localization strings
   -->
 
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.generic.alm.displayName">ALM Eklentisi</message>
 	<message key="plugins.generic.alm.title">Madde Ölçümleri</message>
 	<message key="plugins.generic.alm.loading">Ölçüm Çağırılıyor ...</message>

--- a/locale/zh_CN/locale.xml
+++ b/locale/zh_CN/locale.xml
@@ -11,7 +11,7 @@
   * ALM plugin localization strings
   -->
 
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 
 	<message key="plugins.generic.alm.displayName">ALM 插件</message>
 	<message key="plugins.generic.alm.description">在文章说平密钥中显示插件。为使用ALM服务，您需要DOIs。这项要求在未来有可能会放松。</message>


### PR DESCRIPTION
Following the recent standardization of locale names in the PKP applications, this tackles the ALM plugin.